### PR TITLE
Use defer+follow up rather than respond where possible

### DIFF
--- a/Commands/AnnounceCommand.cs
+++ b/Commands/AnnounceCommand.cs
@@ -95,6 +95,8 @@ public class AnnounceCommand : SlashCommandBase
 
   private async Task ShowTemplate(SocketInteraction interaction, TemplateModel template, bool preview)
   {
+    await interaction.DeferAsync();
+
     if (preview)
     {
       await PreviewTemplate(interaction, template);
@@ -103,7 +105,7 @@ public class AnnounceCommand : SlashCommandBase
     {
       if (template.Channel is null)
       {
-        await interaction.RespondAsync($"{Emotes.ErrorEmote} The channel for this template got deleted");
+        await interaction.FollowupAsync($"{Emotes.ErrorEmote} The channel for this template got deleted");
         return;
       }
 
@@ -116,13 +118,13 @@ public class AnnounceCommand : SlashCommandBase
     var embed = GetAnnouncementEmbed(template);
     if (embed.Length > EmbedBuilder.MaxEmbedLength)
     {
-      await interaction.RespondAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
+      await interaction.FollowupAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
       return;
     }
 
     var mention = template.Mention?.Mention;
     await template.Channel.SendMessageAsync(text: mention, embed: embed.Build());
-    await interaction.RespondAsync($"{Emotes.SuccessEmote} Announced template **{template.Name}**");
+    await interaction.FollowupAsync($"{Emotes.SuccessEmote} Announced template **{template.Name}**");
   }
 
   private async Task PreviewTemplate(SocketInteraction interaction, TemplateModel template)
@@ -130,12 +132,12 @@ public class AnnounceCommand : SlashCommandBase
     var embed = GetAnnouncementEmbed(template);
     if (embed.Length > EmbedBuilder.MaxEmbedLength)
     {
-      await interaction.RespondAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
+      await interaction.FollowupAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
       return;
     }
 
     var mention = template.Mention?.Mention;
-    await interaction.RespondAsync(text: mention, embed: embed.Build(), ephemeral: true);
+    await interaction.FollowupAsync(text: mention, embed: embed.Build(), ephemeral: true);
   }
 
   private EmbedBuilder GetAnnouncementEmbed(TemplateModel template)

--- a/Commands/CustomCommandCommand.cs
+++ b/Commands/CustomCommandCommand.cs
@@ -37,13 +37,15 @@ public class CustomCommandCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     var guild = user.Guild;
     var subcommand = cmd.GetSubcommand();
 
     if (!Authorize(user, subcommand.Name, out var error))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} " + error);
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} " + error);
       return;
     }
 
@@ -67,24 +69,24 @@ public class CustomCommandCommand : SlashCommandBase
 
     if (await service.HasCommand(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Command **{await service.PrefixCommandName(guild, name)}** already exists");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Command **{await service.PrefixCommandName(guild, name)}** already exists");
       return;
     }
 
     if (name.Contains(' '))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Custom commands cannot have spaces in them");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Custom commands cannot have spaces in them");
       return;
     }
 
     if (!ValidateResponse(response, out var error))
     {
-      await cmd.RespondAsync(error);
+      await cmd.FollowupAsync(error);
       return;
     }
 
     await service.AddCommand(guild, name, response, description, delete);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Added command **{await service.PrefixCommandName(guild, name)}**");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Added command **{await service.PrefixCommandName(guild, name)}**");
   }
 
   private bool Authorize(SocketGuildUser user, string subcommand, out string? error)
@@ -104,12 +106,12 @@ public class CustomCommandCommand : SlashCommandBase
 
     if (!await service.HasCommand(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Command **{await service.PrefixCommandName(guild, name)}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Command **{await service.PrefixCommandName(guild, name)}** does not exist");
       return;
     }
 
     await service.RemoveCommand(guild, name);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Removed command **{await service.PrefixCommandName(guild, name)}**");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Removed command **{await service.PrefixCommandName(guild, name)}**");
   }
 
   private async Task ListCommands(SocketSlashCommand cmd, SocketGuild guild)
@@ -117,7 +119,7 @@ public class CustomCommandCommand : SlashCommandBase
     var commands = await service.GetCommands(guild);
     if (commands.Count == 0)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} There are no custom commands");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} There are no custom commands");
       return;
     }
 
@@ -132,7 +134,7 @@ public class CustomCommandCommand : SlashCommandBase
           .WithColor(Colors.Blurple)
       );
 
-    await cmd.RespondAsync(embed: p.Embed, components: p.Components);
+    await cmd.FollowupAsync(embed: p.Embed, components: p.Components);
   }
 
   private bool ValidateResponse(string response, out string? error)

--- a/Commands/CustomEmbedCommand.cs
+++ b/Commands/CustomEmbedCommand.cs
@@ -56,14 +56,16 @@ public class CustomEmbedCommand : SlashCommandBase
 
   private async Task ShowEmbed(SocketInteraction interaction, EmbedBuilder embed, SocketTextChannel channel)
   {
+    await interaction.DeferAsync();
+
     if (embed.Length > EmbedBuilder.MaxEmbedLength)
     {
-      await interaction.RespondAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
+      await interaction.FollowupAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
       return;
     }
 
     await channel.SendMessageAsync(embed: embed.Build());
-    await interaction.RespondAsync($"{Emotes.SuccessEmote} Embed sent");
+    await interaction.FollowupAsync($"{Emotes.SuccessEmote} Embed sent");
   }
 
   private EmbedBuilder GetEmbedToSend(SocketModal modal)

--- a/Commands/CustomRoleCommand.cs
+++ b/Commands/CustomRoleCommand.cs
@@ -34,12 +34,14 @@ public class CustomRoleCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     var subcommand = cmd.GetSubcommand();
 
     if (!Authorize(user, subcommand.Name, out var error))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} " + error);
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} " + error);
       return;
     }
 
@@ -73,19 +75,19 @@ public class CustomRoleCommand : SlashCommandBase
 
     if (await service.HasRole(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Role **{name}** already exists");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Role **{name}** already exists");
       return;
     }
 
     var highestBotRole = guild.CurrentUser.Roles.OrderByDescending(x => x.Position).First();
     if (role.Position > highestBotRole.Position)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Role {role.Mention} is in a higher position than my role ({highestBotRole.Mention}), therefore I won't be able to apply this role to other users");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Role {role.Mention} is in a higher position than my role ({highestBotRole.Mention}), therefore I won't be able to apply this role to other users");
       return;
     }
 
     await service.AddRole(guild, name, description, role);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Added role **{name}** to the list of custom roles");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Added role **{name}** to the list of custom roles");
   }
 
   private async Task RemoveRole(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -94,12 +96,12 @@ public class CustomRoleCommand : SlashCommandBase
 
     if (!await service.HasRole(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Role **{name}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Role **{name}** does not exist");
       return;
     }
 
     await service.RemoveRole(guild, name);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Removed role **{name}** from the list of custom roles");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Removed role **{name}** from the list of custom roles");
   }
 
   private async Task SelectRole(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -108,7 +110,7 @@ public class CustomRoleCommand : SlashCommandBase
     var roles = await service.GetRoles(guild);
     if (roles.Count == 0)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} There are no custom roles");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} There are no custom roles");
       return;
     }
 
@@ -146,7 +148,7 @@ public class CustomRoleCommand : SlashCommandBase
 
       if (tooHighPermRoles.Count > 0)
       {
-        await submitted.RespondAsync($"{Emotes.ErrorEmote} Some of the roles you have selected can't be applied to due permission issues with Discord roles. This incident will be reported", ephemeral: true);
+        await submitted.FollowupAsync($"{Emotes.ErrorEmote} Some of the roles you have selected can't be applied to due permission issues with Discord roles. This incident will be reported", ephemeral: true);
         foreach (var role in tooHighPermRoles)
         {
           await LogService.Instance.LogToDiscord(guild, $"{Emotes.ErrorEmote} Role {role.DiscordRole.Mention} for custom role **{role.Name}** is in a higher position than my role ({highestBotRole.Mention}), therefore I can't apply this role to users");
@@ -154,11 +156,11 @@ public class CustomRoleCommand : SlashCommandBase
         return;
       }
 
-      await submitted.RespondAsync($"{Emotes.SuccessEmote} Your roles have been updated", ephemeral: true);
+      await submitted.FollowupAsync($"{Emotes.SuccessEmote} Your roles have been updated", ephemeral: true);
     };
 
     var components = new ComponentBuilder()
         .WithSelectMenu(menu);
-    await cmd.RespondAsync(components: components.Build(), ephemeral: true);
+    await cmd.FollowupAsync(components: components.Build(), ephemeral: true);
   }
 }

--- a/Commands/EditEmbedMessageCommand.cs
+++ b/Commands/EditEmbedMessageCommand.cs
@@ -83,9 +83,11 @@ public class EditEmbedMessageCommand : MessageCommandBase
 
   private async Task EditEmbed(SocketInteraction interaction, EmbedBuilder embed, SocketTextChannel channel, SocketMessage message)
   {
+    await interaction.DeferAsync();
+
     if (embed.Length > EmbedBuilder.MaxEmbedLength)
     {
-      await interaction.RespondAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
+      await interaction.FollowupAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the announcement cannot be displayed, try recreating the template but shorter");
       return;
     }
 
@@ -93,7 +95,7 @@ public class EditEmbedMessageCommand : MessageCommandBase
     {
       messageProperties.Embed = embed.Build();
     });
-    await interaction.RespondAsync($"{Emotes.SuccessEmote} Embed edited");
+    await interaction.FollowupAsync($"{Emotes.SuccessEmote} Embed edited");
   }
 
   private EmbedBuilder GetEmbedToSend(SocketModal modal)

--- a/Commands/HumanTimeCommand.cs
+++ b/Commands/HumanTimeCommand.cs
@@ -20,6 +20,8 @@ public class HumanTimeCommand : SlashCommandBase
 
   public async override Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var guild = (cmd.Channel as SocketGuildChannel)!.Guild;
 
     var from = cmd.GetOption<string>("from") ?? string.Empty;
@@ -27,7 +29,7 @@ public class HumanTimeCommand : SlashCommandBase
 
     if (string.IsNullOrEmpty(from) && string.IsNullOrEmpty(to))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} You didn't specify any time zone. Perhaps you believe in the Stacked Earth theory?");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} You didn't specify any time zone. Perhaps you believe in the Stacked Earth theory?");
       return;
     }
 
@@ -38,7 +40,7 @@ public class HumanTimeCommand : SlashCommandBase
     }
     catch (FormatException ex)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Invalid from: {ex.Message}");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Invalid from: {ex.Message}");
       return;
     }
     TimeZoneTime toTime;
@@ -48,7 +50,7 @@ public class HumanTimeCommand : SlashCommandBase
     }
     catch (FormatException ex)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Invalid to: {ex.Message}");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Invalid to: {ex.Message}");
       return;
     }
 
@@ -59,6 +61,6 @@ public class HumanTimeCommand : SlashCommandBase
       .AddField("From", $"{fromTime.Time:HH:mm} {fromTime.TimeZoneString}")
       .AddField("To", $"{toTime.Time:HH:mm} {toTime.TimeZoneString}")
       .WithColor(Colors.Blurple);
-    await cmd.RespondAsync(embed: embed.Build());
+    await cmd.FollowupAsync(embed: embed.Build());
   }
 }

--- a/Commands/LevelsCommand.cs
+++ b/Commands/LevelsCommand.cs
@@ -16,6 +16,8 @@ public class LevelsCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var guild = ((SocketGuildChannel)cmd.Channel).Guild;
 
     var leaderboard = await service.GetLeaderboard(guild);
@@ -30,6 +32,6 @@ public class LevelsCommand : SlashCommandBase
           .WithColor(Colors.Blurple)
       );
 
-    await cmd.RespondAsync(embed: p.Embed, components: p.Components);
+    await cmd.FollowupAsync(embed: p.Embed, components: p.Components);
   }
 }

--- a/Commands/LevelupMessage.cs
+++ b/Commands/LevelupMessage.cs
@@ -15,11 +15,13 @@ public class LevelupMessage : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     await service.ToggleLevelupMessage(user);
     var enabled = await service.IsLevelupMessageEnabled(user);
 
     var enabledOut = enabled ? "enabled" : "disabled";
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Levelup message is now {enabledOut} for {user.Mention}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Levelup message is now {enabledOut} for {user.Mention}");
   }
 }

--- a/Commands/NoXPUserCommand.cs
+++ b/Commands/NoXPUserCommand.cs
@@ -15,19 +15,21 @@ public class NoXPUserCommand : UserCommandBase
 
   public override async Task Handle(SocketUserCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     var guild = user.Guild;
     var member = (SocketGuildUser)cmd.Data.Member;
 
     if (!service.IsAuthorized(user, ModrankLevel.Moderator, out var error))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} {error}");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} {error}");
       return;
     }
 
     if (!await service.IsNoXPRoleSet(guild))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} No-XP role was not set");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} No-XP role was not set");
       return;
     }
 
@@ -38,11 +40,11 @@ public class NoXPUserCommand : UserCommandBase
 
     if (isApplied)
     {
-      await cmd.RespondAsync($"{Emotes.SuccessEmote} No-XP role added to {member.Mention}");
+      await cmd.FollowupAsync($"{Emotes.SuccessEmote} No-XP role added to {member.Mention}");
     }
     else
     {
-      await cmd.RespondAsync($"{Emotes.SuccessEmote} No-XP role removed from {member.Mention}");
+      await cmd.FollowupAsync($"{Emotes.SuccessEmote} No-XP role removed from {member.Mention}");
     }
   }
 }

--- a/Commands/PinMessageCommand.cs
+++ b/Commands/PinMessageCommand.cs
@@ -14,6 +14,8 @@ public class PinMessageCommand : MessageCommandBase
 
   public override async Task Handle(SocketMessageCommand cmd)
   {
+    await cmd.DeferAsync();
+
     await service.TryPinningMessage(cmd, cmd.Data.Message);
   }
 }

--- a/Commands/PinSlashCommand.cs
+++ b/Commands/PinSlashCommand.cs
@@ -18,13 +18,15 @@ public class PinSlashCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var messageUrl = cmd.GetOption<string>("link")!;
 
     var formattedMessageUrl = Regex.Match(messageUrl, @"^https:\/\/(canary\.|ptb\.)?discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)");
 
     if (!formattedMessageUrl.Success)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Invalid message link");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Invalid message link");
       return;
     }
 
@@ -45,13 +47,13 @@ public class PinSlashCommand : SlashCommandBase
     }
     catch (Exception)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Invalid message link");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Invalid message link");
       return;
     }
 
     if (inputGuildId != guildId || inputChannelId != channelId)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} You can only pin messages from this channel");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} You can only pin messages from this channel");
       return;
     }
 
@@ -61,7 +63,7 @@ public class PinSlashCommand : SlashCommandBase
 
     if (message == null)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Invalid message link");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Invalid message link");
       return;
     }
 

--- a/Commands/PingCommand.cs
+++ b/Commands/PingCommand.cs
@@ -11,6 +11,7 @@ public class PingCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
-    await cmd.RespondAsync("Pong!");
+    await cmd.DeferAsync();
+    await cmd.FollowupAsync("Pong!");
   }
 }

--- a/Commands/PurgeCommand.cs
+++ b/Commands/PurgeCommand.cs
@@ -18,23 +18,24 @@ public class PurgeCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     var channel = (SocketTextChannel)cmd.Channel;
     var count = (int)cmd.GetOption<long>("count");
 
     if (!service.IsAuthorized(user, ModrankLevel.Moderator, out var error))
     {
-      await cmd.RespondAsync(error);
+      await cmd.FollowupAsync(error);
       return;
     }
 
     if (count > service.MaxPurgeCount)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Cannot purge more than {service.MaxPurgeCount} messages");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Cannot purge more than {service.MaxPurgeCount} messages");
       return;
     }
 
-    await cmd.DeferAsync();
     await service.Purge(cmd, channel, count);
     await cmd.FollowupAsync($"{Emotes.SuccessEmote} Purged {count} messages from {channel.Mention}");
   }

--- a/Commands/RankCommand.cs
+++ b/Commands/RankCommand.cs
@@ -18,6 +18,8 @@ public class RankCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = cmd.GetOption<SocketGuildUser>("user") ?? (SocketGuildUser)cmd.User;
 
     await service.EnsureLevelExists(user);
@@ -33,7 +35,7 @@ public class RankCommand : SlashCommandBase
         .AddField("Progress", $"{level.XPFromThisLevel} XP / {level.TotalLevelXP} XP {progressBar} {percentageOut}%")
         .WithColor(Colors.GetMainRoleColor(user));
 
-    await cmd.RespondAsync(embed: embed.Build());
+    await cmd.FollowupAsync(embed: embed.Build());
   }
 
   private string GetProgressBar(double percentage)

--- a/Commands/RngCommand.cs
+++ b/Commands/RngCommand.cs
@@ -31,6 +31,8 @@ public class RngCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     long rngMin = cmd.GetOption<long>("min", 1);
     long rngMax = cmd.GetOption<long>("max")!;
 
@@ -105,7 +107,7 @@ public class RngCommand : SlashCommandBase
   private async Task PrintFakeRng(SocketSlashCommand cmd)
   {
     var selectedNum = await DatabaseService.QueryFirst<int>("SELECT num FROM rngnums LIMIT(1);");
-    await cmd.RespondAsync(selectedNum.ToString());
+    await cmd.FollowupAsync(selectedNum.ToString());
 
     var user = (SocketGuildUser)cmd.User;
     await LogService.LogToFileAndConsole(
@@ -118,16 +120,16 @@ public class RngCommand : SlashCommandBase
   {
     if (rngMin > rngMax)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Minimum number cannot be bigger than maximum");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Minimum number cannot be bigger than maximum");
       return;
     }
     else if (rngMin == rngMax)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} The two numbers cannot be the same");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} The two numbers cannot be the same");
       return;
     }
 
     long rngNum = Random.Shared.NextInt64(rngMin, rngMax);
-    await cmd.RespondAsync(rngNum.ToString());
+    await cmd.FollowupAsync(rngNum.ToString());
   }
 }

--- a/Commands/SayCommand.cs
+++ b/Commands/SayCommand.cs
@@ -19,12 +19,14 @@ public class SayCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     if (cmd.HasOption("channel"))
     {
       if (!service.IsAuthorized(user, ModrankLevel.Moderator, out var error))
       {
-        await cmd.RespondAsync($"{Emotes.ErrorEmote} " + error);
+        await cmd.FollowupAsync($"{Emotes.ErrorEmote} " + error);
         return;
       }
     }
@@ -34,11 +36,11 @@ public class SayCommand : SlashCommandBase
 
     if (message.Length > 2000)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} The message is too long");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} The message is too long");
       return;
     }
 
     await channel.SendMessageAsync(message);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Message sent", ephemeral: true);
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Message sent", ephemeral: true);
   }
 }

--- a/Commands/ServerinfoCommand.cs
+++ b/Commands/ServerinfoCommand.cs
@@ -16,6 +16,8 @@ public class ServerinfoCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var guild = (cmd.Channel as SocketGuildChannel)!.Guild;
 
     var humans = guild.Users.Count(x => !x.IsBot);
@@ -33,6 +35,6 @@ public class ServerinfoCommand : SlashCommandBase
       .WithColor(Colors.Blurple)
       .WithFooter($"ID: {guild.Id} • Created at {guild.CreatedAt:yyyy-MM-dd}");
 
-    await cmd.RespondAsync(embed: embed.Build());
+    await cmd.FollowupAsync(embed: embed.Build());
   }
 }

--- a/Commands/SettingsCommand.cs
+++ b/Commands/SettingsCommand.cs
@@ -81,13 +81,15 @@ public class SettingsCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     var guild = user.Guild;
     var subcommand = cmd.GetSubcommand();
 
     if (!Authorize(user, subcommand.Name, out var error))
     {
-      await cmd.RespondAsync(error);
+      await cmd.FollowupAsync(error);
       return;
     }
 
@@ -169,28 +171,28 @@ public class SettingsCommand : SlashCommandBase
       .AddField("Autoroles", autoroles.Count > 0 ? string.Join(" ", autoroles) : "None", inline: true)
       .WithColor(Colors.Blurple);
 
-    await cmd.RespondAsync(embed: embed.Build());
+    await cmd.FollowupAsync(embed: embed.Build());
   }
 
   private async Task SetPinChannel(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand)
   {
     var channel = subcommand.GetOption<SocketTextChannel>("channel")!;
     await service.SetPinChannel(channel);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Pin channel set to {channel.Mention}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Pin channel set to {channel.Mention}");
   }
 
   private async Task SetLogChannel(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand)
   {
     var channel = subcommand.GetOption<SocketTextChannel>("channel")!;
     await service.SetLogChannel(channel);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Log channel set to {channel.Mention}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Log channel set to {channel.Mention}");
   }
 
   private async Task SetCommandPrefix(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
   {
     var prefix = subcommand.GetOption<string>("prefix")!;
     await service.SetCommandPrefix(guild, prefix);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Command prefix set to {prefix}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Command prefix set to {prefix}");
   }
 
   private async Task SetModrank(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand)
@@ -198,14 +200,14 @@ public class SettingsCommand : SlashCommandBase
     var role = subcommand.GetOption<SocketRole>("role")!;
     var level = (ModrankLevel)subcommand.GetOption<long>("level")!;
     await service.SetModrank(role, level);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Modrank is now {level} for role {role.Mention}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Modrank is now {level} for role {role.Mention}");
   }
 
   private async Task SetNoXPRole(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand)
   {
     var role = subcommand.GetOption<SocketRole>("role")!;
     await service.SetNoXPRole(role);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} No XP role set to {role.Mention}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} No XP role set to {role.Mention}");
   }
 
   private async Task SetLeaveMessage(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand)
@@ -215,12 +217,12 @@ public class SettingsCommand : SlashCommandBase
 
     if (!message.Contains("$user"))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} The message must contain the placeholder $user");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} The message must contain the placeholder $user");
       return;
     }
 
     await service.SetLeaveMessage(channel, message);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Leave message set to {message} in {channel.Mention}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Leave message set to {message} in {channel.Mention}");
   }
 
   private async Task SetTimeZone(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -234,18 +236,18 @@ public class SettingsCommand : SlashCommandBase
     }
     catch (FormatException ex)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} {ex.Message}");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} {ex.Message}");
       return;
     }
 
     if (parsed.TimeZoneBase is null)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Time zone is not specified");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Time zone is not specified");
       return;
     }
 
     await service.SetTimeZone(guild, parsed);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Time zone set to {parsed.TimeZoneString}");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Time zone set to {parsed.TimeZoneString}");
   }
 
   private async Task AddAutorole(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -254,19 +256,19 @@ public class SettingsCommand : SlashCommandBase
 
     if (await service.HasAutorole(guild, role))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Role {role.Mention} is already an autorole");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Role {role.Mention} is already an autorole");
       return;
     }
 
     var highestBotRole = guild.CurrentUser.Roles.OrderByDescending(x => x.Position).First();
     if(role.Position > highestBotRole.Position)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Role {role.Mention} is in a higher position than my role ({highestBotRole.Mention}), therefore I won't be able to apply this role to new users");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Role {role.Mention} is in a higher position than my role ({highestBotRole.Mention}), therefore I won't be able to apply this role to new users");
       return;
     }
 
     await service.AddAutorole(guild, role);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Added {role.Mention} to autoroles");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Added {role.Mention} to autoroles");
   }
 
   private async Task RemoveAutorole(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -275,11 +277,11 @@ public class SettingsCommand : SlashCommandBase
 
     if (!await service.HasAutorole(guild, role))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Role {role.Mention} is not an autorole");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Role {role.Mention} is not an autorole");
       return;
     }
 
     await service.RemoveAutorole(guild, role);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Removed {role.Mention} from autoroles");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Removed {role.Mention} from autoroles");
   }
 }

--- a/Commands/SnapshotCommand.cs
+++ b/Commands/SnapshotCommand.cs
@@ -46,13 +46,15 @@ public class SnapshotCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = (SocketGuildUser)cmd.User;
     var guild = user.Guild;
     var subcommand = cmd.GetSubcommand();
 
     if (!service.IsAuthorized(user, ModrankLevel.Administrator, out var error))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} " + error);
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} " + error);
       return;
     }
 
@@ -79,12 +81,12 @@ public class SnapshotCommand : SlashCommandBase
 
     if (await service.HasSnapshot(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Snapshot **{name}** already exists");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Snapshot **{name}** already exists");
       return;
     }
 
     await service.AddSnapshot(guild, name, textnames, voicenames, rolenames, servericon);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Added snapshot **{name}**");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Added snapshot **{name}**");
   }
 
   private async Task RemoveSnapshot(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -93,12 +95,12 @@ public class SnapshotCommand : SlashCommandBase
 
     if (!await service.HasSnapshot(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Snapshot **{name}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Snapshot **{name}** does not exist");
       return;
     }
 
     await service.RemoveSnapshot(guild, name);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Removed snapshot **{name}**");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Removed snapshot **{name}**");
   }
 
   private async Task RestoreSnapshot(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuild guild)
@@ -107,11 +109,9 @@ public class SnapshotCommand : SlashCommandBase
 
     if (!await service.HasSnapshot(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Snapshot **{name}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Snapshot **{name}** does not exist");
       return;
     }
-
-    await cmd.DeferAsync();
 
     var message = $"Restoring snapshot **{name}**";
     var result = await service.RestoreSnapshot(guild, name);
@@ -129,7 +129,7 @@ public class SnapshotCommand : SlashCommandBase
 
     if (!await service.HasSnapshot(guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Snapshot **{name}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Snapshot **{name}** does not exist");
       return;
     }
 
@@ -139,12 +139,12 @@ public class SnapshotCommand : SlashCommandBase
     var dumpMessage = $"Dumped snapshot **{name}**:";
     if (s.GuildIcon == null)
     {
-      await cmd.RespondAsync(dumpMessage, embed: dump.Build());
+      await cmd.FollowupAsync(dumpMessage, embed: dump.Build());
     }
     else
     {
       var icon = new FileAttachment(s.GuildIcon.Value.Stream, "servericon.png");
-      await cmd.RespondWithFileAsync(icon, dumpMessage, embed: dump.Build());
+      await cmd.FollowupWithFileAsync(icon, dumpMessage, embed: dump.Build());
     }
   }
   private async Task ListSnapshots(SocketSlashCommand cmd, SocketGuild guild)
@@ -152,7 +152,7 @@ public class SnapshotCommand : SlashCommandBase
     var snapshots = await service.GetSnapshots(guild);
     if (snapshots.Count == 0)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} There are no snapshots");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} There are no snapshots");
       return;
     }
 
@@ -166,6 +166,6 @@ public class SnapshotCommand : SlashCommandBase
           .WithColor(Colors.Blurple)
       );
 
-    await cmd.RespondAsync(embed: p.Embed, components: p.Components);
+    await cmd.FollowupAsync(embed: p.Embed, components: p.Components);
   }
 }

--- a/Commands/TemplateCommand.cs
+++ b/Commands/TemplateCommand.cs
@@ -97,6 +97,8 @@ public class TemplateCommand : SlashCommandBase
     var modal = CreateTemplateModal(t);
     modal.OnSubmitted += async submitted =>
     {
+      await submitted.DeferAsync();
+
       UpdateTemplateFromModal(submitted, t);
       if (!service.ValidateTemplateParameters(submitted, t))
       {
@@ -104,7 +106,7 @@ public class TemplateCommand : SlashCommandBase
       }
 
       await service.AddTemplate(t);
-      await submitted.RespondAsync($"{Emotes.SuccessEmote} Added template **{t.Name}**");
+      await submitted.FollowupAsync($"{Emotes.SuccessEmote} Added template **{t.Name}**");
     };
 
     await cmd.RespondWithModalAsync(modal.Build());
@@ -132,25 +134,29 @@ public class TemplateCommand : SlashCommandBase
 
   private async Task RemoveTemplate(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuildUser user)
   {
+    await cmd.DeferAsync();
+
     var name = subcommand.GetOption<string>("name")!;
 
     if (!await service.HasTemplate(user.Guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Template **{name}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Template **{name}** does not exist");
       return;
     }
 
     await service.RemoveTemplate(user.Guild, name);
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Removed template **{name}**");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Removed template **{name}**");
   }
 
   private async Task DumpTemplate(SocketSlashCommand cmd, SocketSlashCommandDataOption subcommand, SocketGuildUser user)
   {
+    await cmd.DeferAsync();
+
     var name = subcommand.GetOption<string>("name")!;
 
     if (!await service.HasTemplate(user.Guild, name))
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Template **{name}** does not exist");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Template **{name}** does not exist");
       return;
     }
 
@@ -158,20 +164,22 @@ public class TemplateCommand : SlashCommandBase
     var dump = service.GetTemplateDump(t);
     if (dump.Length > EmbedBuilder.MaxEmbedLength)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the template cannot be dumped, try recreating the template but shorter");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} You have reached the maximum embed character limit ({EmbedBuilder.MaxEmbedLength} characters), so the template cannot be dumped, try recreating the template but shorter");
       return;
     }
 
-    await cmd.RespondAsync(text: $"Dump of template **{name}**:", embed: dump.Build());
+    await cmd.FollowupAsync(text: $"Dump of template **{name}**:", embed: dump.Build());
   }
 
   private async Task ListTemplates(SocketSlashCommand cmd, SocketGuildUser user)
   {
+    await cmd.DeferAsync();
+
     var guild = user.Guild;
     var templates = await service.GetTemplates(user.Guild);
     if (templates.Count == 0)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} There are no templates");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} There are no templates");
       return;
     }
 
@@ -186,6 +194,6 @@ public class TemplateCommand : SlashCommandBase
           .WithColor(Colors.Blurple)
       );
 
-    await cmd.RespondAsync(embed: p.Embed, components: p.Components);
+    await cmd.FollowupAsync(embed: p.Embed, components: p.Components);
   }
 }

--- a/Commands/UserinfoCommand.cs
+++ b/Commands/UserinfoCommand.cs
@@ -18,6 +18,8 @@ public class UserinfoCommand : SlashCommandBase
 
   public override async Task Handle(SocketSlashCommand cmd)
   {
+    await cmd.DeferAsync();
+
     var user = cmd.GetOption<SocketGuildUser>("user") ?? (SocketGuildUser)cmd.User;
 
     var firstJoined = await service.FirstJoined(user);
@@ -37,7 +39,7 @@ public class UserinfoCommand : SlashCommandBase
       .WithColor(Colors.GetMainRoleColor(user))
       .WithFooter($"ID: {user.Id}");
 
-    await cmd.RespondAsync(embed: embed.Build());
+    await cmd.FollowupAsync(embed: embed.Build());
   }
 
   private string RolesToString(IReadOnlyCollection<SocketRole> allRoles)

--- a/Services/PinService.cs
+++ b/Services/PinService.cs
@@ -49,7 +49,7 @@ public class PinService
   {
     if (msg.Author.IsBot)
     {
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} Bot messages cannot be pinned");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} Bot messages cannot be pinned");
       return false;
     }
 
@@ -64,7 +64,7 @@ public class PinService
       await LogService.LogToFileAndConsole(
         "No pin channel was set", guild, LogSeverity.Warning);
 
-      await cmd.RespondAsync($"{Emotes.ErrorEmote} No pin channel was set. Set it using `/settings pinchannel`");
+      await cmd.FollowupAsync($"{Emotes.ErrorEmote} No pin channel was set. Set it using `/settings pinchannel`");
       return false;
     }
 
@@ -101,7 +101,7 @@ public class PinService
       await pinChannel!.SendMessageAsync($"**{msg.Author.Username}**: {msg.Content}\n\n{attachments}");
     }
 
-    await cmd.RespondAsync($"{Emotes.SuccessEmote} Message successfully pinned");
+    await cmd.FollowupAsync($"{Emotes.SuccessEmote} Message successfully pinned");
     return true;
   }
 }

--- a/Services/TemplateService.cs
+++ b/Services/TemplateService.cs
@@ -105,7 +105,7 @@ public class TemplateService
         error += "Here is the stuff you have entered:\n";
       }
 
-      modal.RespondAsync($"{Emotes.ErrorEmote} " + error, embed: dump.Build());
+      modal.FollowupAsync($"{Emotes.ErrorEmote} " + error, embed: dump.Build());
       return false;
     }
 


### PR DESCRIPTION
Sometimes the bot doesn't respond to messages the first time due to the 3 second timed, but works on second try, this even happens with the ping command which. This is a Discord.NET or a Discord API issue, pretty sure it's some cold start/bot is sleeping issue.

This PR changes responses to defer as soon as possible, then follow up when the response is ready. This *may* give the bot enough time to defer within 3 seconds, from which it has 15 minutes to follow up. The exceptions for this change is where we use modals, since there's `cmd.RespondWithModalAsync` but no `cmd.FollowupWithModalAsync`.

We are sending one more request to Discord for every command, which makes the bot slower in general. If this change turns out to help, we can improve this by starting the defer at the very start, but only awaiting it before follow up, which would make the code more complex, as we have to await it before every follow up. If the issue persists we can just close this PR.

@YMSTNT I quickly double checked in the code whether I put defers and followups to the right places, but we should test it for a little longer, technically it can happen that the bot crashes with "cannot respond to the same interaction multiple times" or just hangs infinitely with "moe is thinking".
I think this "release schedule" would be good:
- [x] now: testing this in our private server
- [x] 07-14 1 PM: deploying this to raspi to test on public servers
- [ ] 07-21 1 PM: merging or closing this PR